### PR TITLE
Update BaseApiCall.send()

### DIFF
--- a/lib/src/services/api_call.dart
+++ b/lib/src/services/api_call.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:http/http.dart';
-
 import './base_api_call.dart';
 import './node_pool.dart';
 import '../configuration.dart';
@@ -72,20 +70,9 @@ class ApiCall extends BaseApiCall<Map<String, dynamic>> {
             body: json.encode(bodyParameters),
           ));
 
-  /// Handels the [response] from the [node] for a request.
-  ///
-  /// The [response.body] is parsed as JSON and returned if no exceptions are
+  /// The [responseBody] is parsed as JSON and returned if no exceptions are
   /// raised.
   @override
-  Map<String, dynamic> handleNodeResponse(Response response) {
-    final responseBody = json.decode(response.body),
-        responseStatus = response.statusCode;
-
-    if (responseStatus >= 200 && responseStatus < 300) {
-      // If response is 2xx return the body.
-      return responseBody;
-    } else {
-      throw exception(responseBody.toString(), responseStatus);
-    }
-  }
+  Map<String, dynamic> decode(String responseBody) =>
+      responseBody.isEmpty ? {} : json.decode(responseBody);
 }

--- a/lib/src/services/documents_api_call.dart
+++ b/lib/src/services/documents_api_call.dart
@@ -1,7 +1,5 @@
 import 'dart:async';
 
-import 'package:http/http.dart';
-
 import './base_api_call.dart';
 import './node_pool.dart';
 import '../configuration.dart';
@@ -43,18 +41,7 @@ class DocumentsApiCall extends BaseApiCall<String> {
             body: bodyParameters,
           ));
 
-  /// Handels the [response] from the [node] for a request.
-  ///
-  /// The [response.body] is returned if no exceptions are raised.
+  /// The [responseBody] is returned as is.
   @override
-  String handleNodeResponse(Response response) {
-    final responseBody = response.body, responseStatus = response.statusCode;
-
-    if (responseStatus >= 200 && responseStatus < 300) {
-      // If response is 2xx return the body.
-      return responseBody;
-    } else {
-      throw exception(responseBody.toString(), responseStatus);
-    }
-  }
+  String decode(String responseBody) => responseBody;
 }

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -1,6 +1,4 @@
 import 'dart:io';
-import 'dart:convert';
-
 import 'package:http/testing.dart';
 
 import 'package:typesense/src/configuration.dart';
@@ -16,21 +14,7 @@ const protocol = 'http',
     pathToService = '/path/to/service',
     collections = '/collections',
     aliases = '/aliases',
-    companiesAlias = {
-      'name': 'companies',
-      'collection_name': 'companies_june11',
-    },
-    companiesCollectionEndpoint = '$collections/companies',
-    companyCollection = {
-      "name": "companies",
-      "num_documents": 0,
-      "fields": [
-        {"name": "company_name", "type": "string"},
-        {"name": "num_employees", "type": "int32"},
-        {"name": "country", "type": "string", "facet": true}
-      ],
-      "default_sorting_field": "num_employees"
-    };
+    companiesCollectionEndpoint = '$collections/companies';
 
 class ConfigurationFactory {
   ConfigurationFactory._();
@@ -101,116 +85,4 @@ class ConfigurationFactory {
         retryInterval: retryInterval,
         sendApiKeyAsQueryParam: sendApiKeyAsQueryParam,
       );
-}
-
-Future<void> handleHttpRequests(HttpServer server) async {
-  // print('New HTTP server at ${server.address.host}:${server.port}');
-
-  final aliases = <String, Map<String, String>>{};
-  await for (final HttpRequest request in server) {
-    final port = request.connectionInfo.localPort,
-        path = request.uri.path,
-        headers = request.headers,
-        // ignore: unused_local_variable
-        host = headers['host']?.first,
-        _headerApiKey = headers['x-typesense-api-key']?.first;
-
-    // print(
-    //     'Requested host: $host  headerkey: $_headerApiKey  path: $path  queryparams: ${request.uri.queryParameters}');
-
-    if (port == unavailableServerPort) {
-      request.response
-        ..statusCode = HttpStatus.serviceUnavailable
-        ..write('{}')
-        ..close();
-      return;
-    }
-
-    if (_headerApiKey != apiKey &&
-        request.uri.queryParameters['x-typesense-api-key'] != apiKey) {
-      request.response
-        ..statusCode = HttpStatus.unauthorized
-        ..write('{}')
-        ..close();
-      return;
-    }
-
-    switch (request.method) {
-      case 'GET':
-        if (path == '/path/to/service/collections/companies') {
-          request.response
-            ..statusCode = HttpStatus.ok
-            ..headers.contentType = ContentType.json
-            ..write(jsonEncode(companyCollection))
-            ..close();
-        } else if (aliases.containsKey(path)) {
-          request.response
-            ..statusCode = HttpStatus.ok
-            ..headers.contentType = ContentType.json
-            ..write(json.encode(aliases[path]))
-            ..close();
-        } else {
-          request.response
-            ..statusCode = HttpStatus.badRequest
-            ..write('{}')
-            ..close();
-        }
-        break;
-      case 'DELETE':
-        if (path == '/path/to/service/aliases/companies') {
-          request.response
-            ..statusCode = HttpStatus.ok
-            ..headers.contentType = ContentType.json
-            ..write(json.encode(companiesAlias))
-            ..close();
-        } else if (aliases.containsKey(path)) {
-          final map = aliases[path];
-          aliases.remove(path);
-          request.response
-            ..statusCode = HttpStatus.ok
-            ..headers.contentType = ContentType.json
-            ..write(json.encode(map))
-            ..close();
-        } else {
-          request.response
-            ..statusCode = HttpStatus.badRequest
-            ..write('{}')
-            ..close();
-        }
-        break;
-      case 'POST':
-        if (path == '/path/to/service/collections') {
-          request.response
-            ..statusCode = HttpStatus.ok
-            ..headers.contentType = ContentType.json
-            ..write(json.encode(companyCollection))
-            ..close();
-        } else {
-          request.response
-            ..statusCode = HttpStatus.badRequest
-            ..write('{}')
-            ..close();
-        }
-        break;
-      case 'PUT':
-        final map = (jsonDecode(await utf8.decoder.bind(request).join()) as Map)
-            .cast<String, String>();
-        map['name'] = request.uri.pathSegments.last;
-        aliases[path] = map;
-
-        request.response
-          ..statusCode = HttpStatus.ok
-          ..headers.contentType = ContentType.json
-          ..write(json.encode(map))
-          ..close();
-        break;
-      case 'PATCH':
-        break;
-      default:
-        request.response
-          ..statusCode = HttpStatus.methodNotAllowed
-          ..write('{}')
-          ..close();
-    }
-  }
 }


### PR DESCRIPTION
## Change Summary

Rename handleNodeResponse to decode.
exception() is private now.
Remove the logic to fire up a HttpServer to test ApiCall.
Update tests in documents_api_call.dart

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
