### PR TITLE
Add `RequestCache`.

### DIFF
--- a/example/console-simple/pubspec.lock
+++ b/example/console-simple/pubspec.lock
@@ -29,6 +29,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.5"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.6"
   http:
     dependency: transitive
     description:
@@ -43,6 +50,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.4"
+  meta:
+    dependency: transitive
+    description:
+      name: meta
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.4.0"
   path:
     dependency: transitive
     description:

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -2,6 +2,7 @@ import 'dart:collection';
 
 import 'configuration.dart';
 import 'services/node_pool.dart';
+import 'services/request_cache.dart';
 import 'services/api_call.dart';
 import 'services/documents_api_call.dart';
 import 'services/collections_api_call.dart';
@@ -47,7 +48,8 @@ class Client {
       this.multiSearch);
 
   factory Client(Configuration config) {
-    final nodePool = NodePool(config), apiCall = ApiCall(config, nodePool);
+    final nodePool = NodePool(config),
+        apiCall = ApiCall(config, nodePool, RequestCache());
     return Client._(
         config,
         apiCall,

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -1,9 +1,9 @@
-import 'package:collection/collection.dart';
+import 'package:equatable/equatable.dart';
 
 import 'exceptions/exceptions.dart' show MissingConfiguration;
 import 'models/node.dart';
 
-class Configuration {
+class Configuration extends Equatable {
   final Set<Node> nodes;
   final Node nearestNode;
   final Duration connectionTimeout;
@@ -12,6 +12,7 @@ class Configuration {
   final Duration retryInterval;
   final String apiKey;
   final bool sendApiKeyAsQueryParam;
+  final Duration cachedSearchResultsTTL;
 
   const Configuration._({
     this.nodes,
@@ -22,6 +23,7 @@ class Configuration {
     this.retryInterval,
     this.apiKey,
     this.sendApiKeyAsQueryParam,
+    this.cachedSearchResultsTTL,
   });
 
   factory Configuration({
@@ -33,6 +35,7 @@ class Configuration {
     Duration retryInterval,
     String apiKey,
     bool sendApiKeyAsQueryParam,
+    Duration cachedSearchResultsTTL,
   }) {
     if (nodes == null || nodes.isEmpty) {
       throw MissingConfiguration('Ensure that Configuration.nodes is set');
@@ -50,6 +53,8 @@ class Configuration {
       retryInterval: retryInterval ??= Duration(milliseconds: 100),
       apiKey: apiKey,
       sendApiKeyAsQueryParam: sendApiKeyAsQueryParam ??= false,
+      cachedSearchResultsTTL: cachedSearchResultsTTL ??=
+          Duration.zero, // Disable cache by default
     );
   }
 
@@ -63,6 +68,7 @@ class Configuration {
     Duration retryInterval,
     String apiKey,
     bool sendApiKeyAsQueryParam,
+    Duration cachedSearchResultsTTL,
   }) =>
       Configuration._(
         nodes: nodes ?? original.nodes,
@@ -75,6 +81,8 @@ class Configuration {
         apiKey: apiKey ?? original.apiKey,
         sendApiKeyAsQueryParam:
             sendApiKeyAsQueryParam ?? original.sendApiKeyAsQueryParam,
+        cachedSearchResultsTTL:
+            cachedSearchResultsTTL ?? original.cachedSearchResultsTTL,
       );
 
   @override
@@ -88,31 +96,22 @@ class Configuration {
   Retry interval: $retryInterval
   Api key: $apiKey
   Send api key in query: $sendApiKeyAsQueryParam
+  Cached search results Time To Live: $cachedSearchResultsTTL
 }
 ''';
 
   @override
-  bool operator ==(Object o) =>
-      identical(this, o) ||
-      (o is Configuration &&
-          runtimeType == o.runtimeType &&
-          SetEquality<Node>().equals(this.nodes, o.nodes) &&
-          this.nearestNode == o.nearestNode &&
-          this.connectionTimeout == o.connectionTimeout &&
-          this.healthcheckInterval == o.healthcheckInterval &&
-          this.numRetries == o.numRetries &&
-          this.retryInterval == o.retryInterval &&
-          this.apiKey == o.apiKey &&
-          this.sendApiKeyAsQueryParam == o.sendApiKeyAsQueryParam);
-
-  @override
-  int get hashCode =>
-      nodes.hashCode ^
-      nearestNode.hashCode ^
-      connectionTimeout.hashCode ^
-      healthcheckInterval.hashCode ^
-      numRetries.hashCode ^
-      retryInterval.hashCode ^
-      apiKey.hashCode ^
-      sendApiKeyAsQueryParam.hashCode;
+  List<Object> get props {
+    return [
+      nodes,
+      nearestNode,
+      connectionTimeout,
+      healthcheckInterval,
+      numRetries,
+      retryInterval,
+      apiKey,
+      sendApiKeyAsQueryParam,
+      cachedSearchResultsTTL,
+    ];
+  }
 }

--- a/lib/src/documents.dart
+++ b/lib/src/documents.dart
@@ -90,6 +90,15 @@ class Documents {
     return await _documentApiCall.get('$_endPoint/export');
   }
 
+  Future<Map<String, dynamic>> search(
+      Map<String, dynamic> searchParameters) async {
+    return await _apicall.get(
+      '$_endPoint/search',
+      queryParams: searchParameters,
+      shouldCacheResult: true,
+    );
+  }
+
   String get _endPoint =>
       "${Collections.RESOURCEPATH}/$_collectionName${Documents.RESOURCEPATH}";
 }

--- a/lib/src/multi_search.dart
+++ b/lib/src/multi_search.dart
@@ -14,9 +14,12 @@ class MultiSearch {
     if (useTextContentType) {
       additionalHeaders[CONTENT_TYPE] = 'text/plain';
     }
-    return await _apiCall.post(RESOURCEPATH,
-        bodyParameters: searchRequests,
-        queryParams: queryParams,
-        additionalHeaders: additionalHeaders);
+    return await _apiCall.post(
+      RESOURCEPATH,
+      bodyParameters: searchRequests,
+      queryParams: queryParams,
+      additionalHeaders: additionalHeaders,
+      shouldCacheResult: true,
+    );
   }
 }

--- a/lib/src/search_client.dart
+++ b/lib/src/search_client.dart
@@ -4,6 +4,7 @@ import 'configuration.dart';
 import 'multi_search.dart';
 import 'collection.dart';
 import 'services/node_pool.dart';
+import 'services/request_cache.dart';
 import 'services/api_call.dart';
 import 'services/documents_api_call.dart';
 
@@ -31,7 +32,8 @@ class SearchClient {
       sendApiKeyAsQueryParam: (config.apiKey.length < 2000),
     );
 
-    final nodePool = NodePool(config), apiCall = ApiCall(config, nodePool);
+    final nodePool = NodePool(config),
+        apiCall = ApiCall(config, nodePool, RequestCache());
     return SearchClient._(
       config,
       apiCall,

--- a/lib/src/services/api_call.dart
+++ b/lib/src/services/api_call.dart
@@ -1,27 +1,51 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:collection';
 
-import './base_api_call.dart';
-import './node_pool.dart';
+import 'base_api_call.dart';
+import 'node_pool.dart';
+import 'request_cache.dart';
 import '../configuration.dart';
 
-export './base_api_call.dart' show CONTENT_TYPE;
+export 'base_api_call.dart' show CONTENT_TYPE;
 
 /// Handles requests that expect JSON data of `Map<String, dynamic>` type from
 /// the server.
 class ApiCall extends BaseApiCall<Map<String, dynamic>> {
-  ApiCall(Configuration config, NodePool nodePool) : super(config, nodePool);
+  final RequestCache _requestCache;
+
+  ApiCall(Configuration config, NodePool nodePool, RequestCache requestCache)
+      : _requestCache = requestCache,
+        super(config, nodePool);
 
   /// Sends an HTTP GET request to the URL constructed using the [Node.uri],
   /// [endpoint] and [queryParams].
+  ///
+  /// Set [shouldCacheResult] to `true` if the response is supposed to be cached.
+  /// For caching to take effect, [Configuration.cachedSearchResultsTTL] needs
+  /// to be set.
   Future<Map<String, dynamic>> get(
     String endpoint, {
     Map<String, dynamic> queryParams = const {},
+    bool shouldCacheResult = false,
   }) =>
-      send((node) => node.client.get(
-            requestUri(node, endpoint, queryParams),
-            headers: defaultHeaders,
-          ));
+      shouldCacheResult && config.cachedSearchResultsTTL != Duration.zero
+          ? _requestCache.cache(
+              // SplayTreeMap ensures order of the parameters is maintained so
+              // cache key won't differ because of different ordering of
+              // parameters.
+              '${endpoint}${SplayTreeMap.from(queryParams)}'.hashCode,
+              send,
+              (node) => node.client.get(
+                requestUri(node, endpoint, queryParams),
+                headers: defaultHeaders,
+              ),
+              config.cachedSearchResultsTTL,
+            )
+          : send((node) => node.client.get(
+                requestUri(node, endpoint, queryParams),
+                headers: defaultHeaders,
+              ));
 
   /// Sends an HTTP DELETE request to the URL constructed using the [Node.uri],
   /// [endpoint] and [queryParams].
@@ -38,27 +62,53 @@ class ApiCall extends BaseApiCall<Map<String, dynamic>> {
   /// [bodyParameters] to the URL constructed using the [Node.uri], [endpoint]
   /// and [queryParams].
   ///
-  /// [bodyParameters] sets the body of the request. It's encoded as json and
-  /// used as the body of the request. The content-type of the request is
-  /// "application/json".
+  /// [bodyParameters] is json encoded and sent as the body of the request. The
+  /// content-type of the request is "application/json".
+  /// If [bodyParameters] contains objects that are not directly encodable to a
+  /// JSON string (a value that is not a number, boolean, string, null, list or
+  /// a map with string keys), it defaults to a function that returns the result
+  /// of calling `.toJson()` on the unencodable object.
+  ///
+  /// Set [shouldCacheResult] to `true` if the response is supposed to be cached.
+  /// For caching to take effect, [Configuration.cachedSearchResultsTTL] needs
+  /// to be set.
   Future<Map<String, dynamic>> post(
     String endpoint, {
     Map<String, dynamic> queryParams = const {},
     Map<String, String> additionalHeaders = const {},
     Object bodyParameters,
+    bool shouldCacheResult = false,
   }) =>
-      send((node) => node.client.post(
-            requestUri(node, endpoint, queryParams),
-            headers: {...defaultHeaders, ...additionalHeaders},
-            body: json.encode(bodyParameters),
-          ));
+      shouldCacheResult && config.cachedSearchResultsTTL != Duration.zero
+          ? _requestCache.cache(
+              // SplayTreeMap ensures order of the parameters is maintained so
+              // cache key won't differ because of different ordering of
+              // parameters.
+              '${endpoint}${SplayTreeMap.from(queryParams)}${SplayTreeMap.from(additionalHeaders)}${json.encode(bodyParameters)}'
+                  .hashCode,
+              send,
+              (node) => node.client.post(
+                requestUri(node, endpoint, queryParams),
+                headers: {...defaultHeaders, ...additionalHeaders},
+                body: json.encode(bodyParameters),
+              ),
+              config.cachedSearchResultsTTL,
+            )
+          : send((node) => node.client.post(
+                requestUri(node, endpoint, queryParams),
+                headers: {...defaultHeaders, ...additionalHeaders},
+                body: json.encode(bodyParameters),
+              ));
 
   /// Sends an HTTP PUT request with the given [bodyParameters] to the URL
   /// constructed using the [Node.uri], [endpoint] and [queryParams].
   ///
-  /// [bodyParameters] sets the body of the request. It's encoded as json and
-  /// used as the body of the request. The content-type of the request is
-  /// "application/json".
+  /// [bodyParameters] is json encoded and sent as the body of the request. The
+  /// content-type of the request is "application/json".
+  /// If [bodyParameters] contains objects that are not directly encodable to a
+  /// JSON string (a value that is not a number, boolean, string, null, list or
+  /// a map with string keys), it defaults to a function that returns the result
+  /// of calling `.toJson()` on the unencodable object.
   Future<Map<String, dynamic>> put(
     String endpoint, {
     Map<String, dynamic> queryParams = const {},
@@ -73,9 +123,12 @@ class ApiCall extends BaseApiCall<Map<String, dynamic>> {
   /// Sends an HTTP PATCH request with the given [bodyParameters] to the URL
   /// constructed using the [Node.uri], [endpoint] and [queryParams].
   ///
-  /// [bodyParameters] sets the body of the request. It's encoded as json and
-  /// used as the body of the request. The content-type of the request is
-  /// "application/json".
+  /// [bodyParameters] is json encoded and sent as the body of the request. The
+  /// content-type of the request is "application/json".
+  /// If [bodyParameters] contains objects that are not directly encodable to a
+  /// JSON string (a value that is not a number, boolean, string, null, list or
+  /// a map with string keys), it defaults to a function that returns the result
+  /// of calling `.toJson()` on the unencodable object.
   Future<Map<String, dynamic>> patch(
     String endpoint, {
     Map<String, dynamic> queryParams = const {},

--- a/lib/src/services/base_api_call.dart
+++ b/lib/src/services/base_api_call.dart
@@ -22,18 +22,18 @@ const _API_KEY = 'X-TYPESENSE-API-KEY';
 /// [R] stands for the response type that the sub-class implementing
 /// [BaseApiCall] promises.
 abstract class BaseApiCall<R extends Object> {
-  final Configuration _config;
+  final Configuration config;
   final NodePool _nodePool;
   Map<String, String> _defaultHeaders = {};
   Map<String, String> _defaultQueryParameters = {};
 
   BaseApiCall(Configuration config, NodePool nodePool)
-      : _config = config,
+      : config = config,
         _nodePool = nodePool {
-    if (_config.sendApiKeyAsQueryParam) {
-      _defaultQueryParameters[_API_KEY] = _config.apiKey;
+    if (config.sendApiKeyAsQueryParam) {
+      _defaultQueryParameters[_API_KEY] = config.apiKey;
     } else {
-      _defaultHeaders[_API_KEY] = _config.apiKey;
+      _defaultHeaders[_API_KEY] = config.apiKey;
     }
 
     _defaultHeaders[CONTENT_TYPE] = 'application/json';
@@ -56,11 +56,11 @@ abstract class BaseApiCall<R extends Object> {
   Future<R> send(Future<http.Response> Function(Node) request) async {
     http.Response response;
     Node node;
-    for (var triesLeft = _config.numRetries;;) {
+    for (var triesLeft = config.numRetries;;) {
       node = _nodePool.nextNode;
       try {
         response = await request(node).timeout(
-          _config.connectionTimeout,
+          config.connectionTimeout,
         );
 
         if (response.statusCode >= 1 && response.statusCode <= 499) {
@@ -92,7 +92,7 @@ abstract class BaseApiCall<R extends Object> {
           // We've exhausted our tries, rethrow.
           rethrow;
         } else {
-          await Future.delayed(_config.retryInterval);
+          await Future.delayed(config.retryInterval);
         }
       }
     }

--- a/lib/src/services/request_cache.dart
+++ b/lib/src/services/request_cache.dart
@@ -1,0 +1,44 @@
+import 'dart:collection';
+
+import 'package:http/http.dart' as http;
+
+import '../models/node.dart';
+
+/// Cache store which uses a [HashMap] internally to serve requests.
+class RequestCache {
+  final _cachedResponses = HashMap<int, _Cache>();
+
+  /// Caches the response of the [request], identified by [key]. The cached
+  /// response is valid till [cacheTTL].
+  Future<Map<String, dynamic>> cache(
+    int key,
+    Future<Map<String, dynamic>> Function(Future<http.Response> Function(Node))
+        send,
+    Future<http.Response> Function(Node) request,
+    Duration cacheTTL,
+  ) async {
+    if (_cachedResponses.containsKey(key)) {
+      if (_isCacheValid(_cachedResponses[key], cacheTTL)) {
+        // Cache entry is still valid, return it
+        return Future.value(_cachedResponses[key].data);
+      } else {
+        // Cache entry has expired, so delete it explicitly
+        _cachedResponses.remove(key);
+      }
+    }
+
+    final response = await send(request);
+    _cachedResponses[key] = _Cache(response, DateTime.now());
+    return response;
+  }
+
+  bool _isCacheValid(_Cache cache, Duration cacheTTL) =>
+      DateTime.now().difference(cache.creationTime) < cacheTTL;
+}
+
+class _Cache {
+  final DateTime creationTime;
+  final Map<String, dynamic> data;
+
+  const _Cache(this.data, this.creationTime);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 
 dependencies:
   http: ^0.12.2
-  collection: ^1.14.13
   crypto: ^2.1.5
+  equatable: 1.2.6
 
 dev_dependencies:
   test: ^1.15.7

--- a/test/configuration_test.dart
+++ b/test/configuration_test.dart
@@ -1,11 +1,10 @@
 import 'package:test/test.dart';
+import 'package:equatable/equatable.dart';
 
 import 'package:typesense/src/configuration.dart';
 import 'package:typesense/src/models/node.dart';
 import 'package:typesense/src/exceptions/exceptions.dart'
     show MissingConfiguration;
-
-import 'test_utils.dart';
 
 void main() {
   final config = Configuration(
@@ -27,6 +26,7 @@ void main() {
     numRetries: 5,
     retryInterval: Duration(seconds: 3),
     sendApiKeyAsQueryParam: true,
+    cachedSearchResultsTTL: Duration(seconds: 30),
   );
 
   group('Configuration', () {
@@ -60,6 +60,9 @@ void main() {
     });
     test('has a sendApiKeyAsQueryParam field', () {
       expect(config.sendApiKeyAsQueryParam, isTrue);
+    });
+    test('has a cacheSearchResults field', () {
+      expect(config.cachedSearchResultsTTL, equals(Duration(seconds: 30)));
     });
   });
 
@@ -276,17 +279,12 @@ void main() {
       expect(updatedConfig.nodes, equals(config.nodes));
       expect(updatedConfig.numRetries, equals(config.numRetries));
       expect(updatedConfig.retryInterval, equals(config.retryInterval));
+      expect(updatedConfig.cachedSearchResultsTTL,
+          equals(config.cachedSearchResultsTTL));
     });
   });
 
-  test('Configurations are equatable', () {
-    expect(
-        ConfigurationFactory.withNearestNode ==
-            ConfigurationFactory.withNearestNode,
-        isTrue);
-    expect(
-        ConfigurationFactory.withoutNearestNode ==
-            ConfigurationFactory.withoutNearestNode,
-        isTrue);
+  test('Configuration extends Equatable', () {
+    expect(config, isA<Equatable>());
   });
 }

--- a/test/documents_test.dart
+++ b/test/documents_test.dart
@@ -120,6 +120,60 @@ void main() {
       )).thenAnswer((realInvocation) => Future.value(documentJsonl));
       expect(await documents.exportJsonlDocuments(), equals(documentJsonl));
     });
+    test('search() calls ApiCall.get with shouldCacheResult true', () async {
+      final searchResult = {
+        "facet_counts": [],
+        "found": 1,
+        "out_of": 1,
+        "page": 1,
+        "request_params": {"q": ""},
+        "search_time_ms": 1,
+        "grouped_hits": [
+          {
+            "group_key": ["USA"],
+            "hits": [
+              {
+                "highlights": [
+                  {
+                    "field": "company_name",
+                    "snippet": "<mark>Stark</mark> Industries"
+                  }
+                ],
+                "document": {
+                  "id": "124",
+                  "company_name": "Stark Industries",
+                  "num_employees": 5215,
+                  "country": "USA"
+                }
+              }
+            ]
+          }
+        ]
+      };
+
+      when(mockApiCall.get(
+        "/collections/companies/documents/search",
+        queryParams: {
+          'q': 'stark',
+          'query_by': 'company_name',
+          'filter_by': 'num_employees:>100',
+          'sort_by': 'num_employees:desc',
+          'group_by': 'country',
+          'group_limit': '1'
+        },
+        shouldCacheResult: true,
+      )).thenAnswer((realInvocation) => Future.value(searchResult));
+      expect(
+          await documents.search({
+            'q': 'stark',
+            'query_by': 'company_name',
+            'filter_by': 'num_employees:>100',
+            'sort_by': 'num_employees:desc',
+            'group_by': 'country',
+            'group_limit': '1'
+          }),
+          equals(searchResult));
+    });
   });
 
   test('Documents.importDocuments throws ImportError if "success" is false',

--- a/test/multi_search_test.dart
+++ b/test/multi_search_test.dart
@@ -2,7 +2,6 @@ import 'package:test/test.dart';
 import 'package:mockito/mockito.dart';
 
 import 'package:typesense/src/services/api_call.dart';
-
 import 'package:typesense/src/multi_search.dart';
 
 class MockApiCall extends Mock implements ApiCall {}

--- a/test/multi_search_test.dart
+++ b/test/multi_search_test.dart
@@ -75,7 +75,8 @@ void main() {
     test('has a RESOURCEPATH', () {
       expect(MultiSearch.RESOURCEPATH, equals('/multi_search'));
     });
-    test('perform() calls ApiCall.post()', () async {
+    test('perform() calls ApiCall.post() with shouldCacheResult true',
+        () async {
       when(
         mock.post(
           '/multi_search',
@@ -95,6 +96,7 @@ void main() {
           queryParams: {
             'query_by': 'name',
           },
+          shouldCacheResult: true,
         ),
       ).thenAnswer((realInvocation) => Future.value(map));
       expect(
@@ -119,5 +121,53 @@ void main() {
           equals(map));
     });
   });
-  // TODO: Add test which sets useTextContentType to true
+
+  test(
+      'MultiSearch when initialized with useTextContentType true sets CONTENT_TYPE to "text/plain"',
+      () async {
+    final multiSearch = MultiSearch(mock, useTextContentType: true);
+    when(
+      mock.post(
+        '/multi_search',
+        bodyParameters: {
+          'searches': [
+            {
+              'collection': 'products',
+              'q': 'shoe',
+              'filter_by': 'price:=[50..120]',
+            },
+            {
+              'collection': 'brands',
+              'q': 'Nike',
+            }
+          ]
+        },
+        queryParams: {
+          'query_by': 'name',
+        },
+        additionalHeaders: {'Content-Type': 'text/plain'},
+        shouldCacheResult: true,
+      ),
+    ).thenAnswer((realInvocation) => Future.value(map));
+    expect(
+        await multiSearch.perform(
+          {
+            'searches': [
+              {
+                'collection': 'products',
+                'q': 'shoe',
+                'filter_by': 'price:=[50..120]',
+              },
+              {
+                'collection': 'brands',
+                'q': 'Nike',
+              }
+            ]
+          },
+          queryParams: {
+            'query_by': 'name',
+          },
+        ),
+        equals(map));
+  });
 }

--- a/test/services/documents_api_call_test.dart
+++ b/test/services/documents_api_call_test.dart
@@ -110,7 +110,7 @@ void main() {
       expect(await docsApiCall.send((node) => Future.value(mockReponse)),
           equals('{"success": true}'));
     });
-    test('has a handleNodeResponse method', () {
+    test('has a decode method', () {
       final config = ConfigurationFactory.withNearestNode(),
           nodePool = NodePool(config),
           docsApiCall = DocumentsApiCall(config, nodePool),

--- a/test/services/request_cache_test.dart
+++ b/test/services/request_cache_test.dart
@@ -1,0 +1,96 @@
+import 'dart:convert';
+
+import 'package:test/test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:typesense/src/services/request_cache.dart';
+import 'package:typesense/src/models/node.dart';
+
+import '../test_utils.dart';
+
+class MockResponse extends Mock implements http.Response {}
+
+void main() {
+  group('RequestCache', () {
+    RequestCache requestCache;
+    MockResponse mockResponse;
+    int requestNumber;
+    Future<Map<String, dynamic>> Function(Future<http.Response> Function(Node))
+        send;
+    Future<http.Response> Function(Node) request;
+    final cacheTTL = Duration(seconds: 1);
+    setUp(() {
+      requestCache = RequestCache();
+      mockResponse = MockResponse();
+      requestNumber = 1;
+
+      when(mockResponse.body).thenAnswer((invocation) {
+        switch (requestNumber++) {
+          case 1:
+            return json.encode({'value': 'initial'});
+
+          case 2:
+            return json.encode({'value': 'updated'});
+
+          default:
+            return json.encode({});
+        }
+      });
+
+      send = (request) async {
+        final response = await request(
+            Node(protocol: protocol, host: host, path: pathToService));
+        return json.decode(response.body);
+      };
+      request = (node) => Future.value(mockResponse);
+    });
+
+    test('caches the response', () async {
+      expect(
+          await requestCache.cache(
+            '/value'.hashCode,
+            send,
+            request,
+            cacheTTL,
+          ),
+          equals({'value': 'initial'}));
+      expect(
+          await requestCache.cache(
+            '/value'.hashCode,
+            send,
+            request,
+            cacheTTL,
+          ),
+          equals({'value': 'initial'}));
+    });
+    test('refreshes the cache after TTL duration', () async {
+      expect(
+          await requestCache.cache(
+            '/value'.hashCode,
+            send,
+            request,
+            cacheTTL,
+          ),
+          equals({'value': 'initial'}));
+      expect(
+          await requestCache.cache(
+            '/value'.hashCode,
+            send,
+            request,
+            cacheTTL,
+          ),
+          equals({'value': 'initial'}));
+
+      await Future.delayed(Duration(seconds: 1, milliseconds: 100));
+      expect(
+          await requestCache.cache(
+            '/value'.hashCode,
+            send,
+            request,
+            cacheTTL,
+          ),
+          equals({'value': 'updated'}));
+    });
+  });
+}

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -29,6 +29,7 @@ class ConfigurationFactory {
     String apiKey = apiKey,
     bool sendApiKeyAsQueryParam = false,
     MockClient mockClient,
+    Duration cachedSearchResultsTTL,
   }) =>
       Configuration(
         nearestNode: nearestNode ??
@@ -55,6 +56,7 @@ class ConfigurationFactory {
         apiKey: apiKey,
         retryInterval: retryInterval,
         sendApiKeyAsQueryParam: sendApiKeyAsQueryParam,
+        cachedSearchResultsTTL: cachedSearchResultsTTL,
       );
 
   static Configuration withoutNearestNode({
@@ -66,6 +68,7 @@ class ConfigurationFactory {
     String apiKey = apiKey,
     bool sendApiKeyAsQueryParam = false,
     MockClient mockClient,
+    Duration cachedSearchResultsTTL,
   }) =>
       Configuration(
         nodes: nodes ??
@@ -84,5 +87,6 @@ class ConfigurationFactory {
         apiKey: apiKey,
         retryInterval: retryInterval,
         sendApiKeyAsQueryParam: sendApiKeyAsQueryParam,
+        cachedSearchResultsTTL: cachedSearchResultsTTL,
       );
 }


### PR DESCRIPTION
## Change Summary
* Add `RequestCache` (#56).
* Add `Configuration.cachedSearchResultsTTL`.
* Add `Documents.search`
* Update `Configuration` to extend `Equatable`.
* Update `ApiCall.get` and `ApiCall.post` to optionally cache results.
* `MultiSeach.perform` caches the response.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
